### PR TITLE
Replaced malloc check in autotools to avoid failure on NetBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,8 +58,7 @@ AC_TYPE_SSIZE_T
 # Checks for library functions.
 AC_FUNC_FORK
 AC_FUNC_LSTAT_FOLLOWS_SLASHED_SYMLINK
-AC_FUNC_MALLOC
-AC_CHECK_FUNCS([strchr strdup strrchr])
+AC_CHECK_FUNCS([strchr strdup strrchr malloc])
 AC_CHECK_FUNCS([dup2 putenv select setenv strerror],, [AC_MSG_ERROR([seems as if your libraries don't provide an expected function])])
 
 AC_CONFIG_FILES([Makefile])


### PR DESCRIPTION
Fixes #13 on gnosek/fcgiwrap.
