### PR TITLE
prefork: Fix 100% CPU usage in parent process

### DIFF
--- a/fcgiwrap.c
+++ b/fcgiwrap.c
@@ -623,7 +623,7 @@ static void sigchld_handler(int dummy)
 {
 	int status;
 
-	while ((dummy = waitpid(-1, &status, WNOHANG)) != -1) {
+	while ((dummy = waitpid(-1, &status, WNOHANG)) > 0) {
 		/* sanity check */
 		if (nrunning > 0)
 			nrunning--;


### PR DESCRIPTION
When a child process is terminated, the parent calls waitpid() to check
for dead children. This returns -1 on error (e.g. there are no other
children or a signal interrupted waitpid()), the pid (> 0) for dead
children OR 0 if there are some children which are still alive.

Fixes gnosek/fcgiwrap#18.
