### PR TITLE
Socket cleanup on exit

### DIFF
--- a/fcgiwrap.c
+++ b/fcgiwrap.c
@@ -623,7 +623,7 @@ static void fcgiwrap_main(void)
 	a.sa_flags = 0;
 	sigemptyset( &a.sa_mask );
 	sigaction( SIGINT, &a, NULL );
-	sigaction( SIGQUIT, &a, NULL );
+	sigaction( SIGTERM, &a, NULL );
 
 	inherited_environ = environ;
 

--- a/fcgiwrap.c
+++ b/fcgiwrap.c
@@ -853,7 +853,6 @@ int main(int argc, char **argv)
 		if (setup_socket(socket_url, &fd) < 0) {
 			return 1;
 		}
-		free(socket_url);
 	}
 
 	prefork(nchildren);
@@ -863,9 +862,12 @@ int main(int argc, char **argv)
 		const char *p = socket_url;
 		close(fd);
 
-		if (!strncmp(p, "unix:", sizeof("unix:") - 1)) {
-			p += sizeof("unix:") - 1;
-			unlink(p);
+		if(socket_url) {
+			if (!strncmp(p, "unix:", sizeof("unix:") - 1)) {
+				p += sizeof("unix:") - 1;
+				unlink(p);
+			}
+			free(socket_url);
 		}
 	}
 	return 0;


### PR DESCRIPTION
When using unix sockets, bind() will fail with "Address already in use" if the file already exists. fcgiwrap did not clean up the socket properly on exit, and we failed to restart.

The FreeBSD ports init script did this cleanup manually when "stop" was executed. However, on system reboot, the initscripts are not called, with the result that manual intervention was required on system boot.

Patch tested and works on FreeBSD 10.0, should be tested on other supported platforms as well, but it's pretty  straightforward POSIX signal handling, so it should probably be OK I think.

Note that it will still fail to startup if the machine totally crashes; the alternative would be to unlink the socket before trying to bind, but that comes with other concerns.
