### PR TITLE
Update fcgiwrap.service

### DIFF
--- a/systemd/fcgiwrap.service
+++ b/systemd/fcgiwrap.service
@@ -3,7 +3,7 @@ Description=Simple CGI Server
 After=nss-user-lookup.target
 
 [Service]
-ExecStart=/usr/sbin/fcgiwrap
+ExecStart=/usr/local/sbin/fcgiwrap
 User=http
 Group=http
 


### PR DESCRIPTION
Since fcgiwrap is installed to /usr/local/sbin by default the systemd service file should reflect that. It would probably be better to automatically update the executable location depending on DESTDIR and/or --prefix.
