### PR TITLE
Provide fixes to the build system

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -16,7 +16,7 @@ ifneq ("@systemdsystemunitdir@", "")
 	install -m 644 systemd/fcgiwrap.service $(DESTDIR)@systemdsystemunitdir@
 endif
 
-LDLIBS = -lfcgi @systemd_LIBS@
+LDLIBS = @LIBS@ @systemd_LIBS@
 CFLAGS = @AM_CFLAGS@
 
 fcgiwrap: fcgiwrap.c

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ AC_ARG_WITH([systemd],
   [], [with_systemd=check])
 have_systemd=no
 if test "x$with_systemd" != "xno"; then
-  PKG_CHECK_MODULES(systemd, [libsystemd-daemon],
+  PKG_CHECK_MODULES(systemd, [libsystemd],
     [AC_DEFINE(HAVE_SYSTEMD, 1, [Define if systemd is available])
     have_systemd=yes],
   have_systemd=no)


### PR DESCRIPTION
- Use `@LIBS@`  from `configure` in `Makefile.in` (this helps statically linking fcgiwrap), and
- link with `libsystemd` rather than `libsystemd-daemon`, as needed by latest versions of systemd.
