### PR TITLE
Restrict permissions in systemd/fcgiwrap.socket.

### DIFF
--- a/systemd/fcgiwrap.socket
+++ b/systemd/fcgiwrap.socket
@@ -3,6 +3,8 @@ Description=fcgiwrap Socket
 
 [Socket]
 ListenStream=/run/fcgiwrap.sock
+SocketUser=http
+SocketMode=0660
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
The default SocketMode is 0666, which means that anybody could execute scripts as the user fcgiwrap runs as.
