### PR TITLE
Declare cgi_error noreturn

### DIFF
--- a/fcgiwrap.c
+++ b/fcgiwrap.c
@@ -500,6 +500,7 @@ static bool is_allowed_program(const char *program) {
 	return false;
 }
 
+__attribute__((__noreturn__))
 static void cgi_error(const char *message, const char *reason, const char *filename)
 {
 	printf("Status: %s\r\nContent-Type: text/plain\r\n\r\n%s\r\n",


### PR DESCRIPTION
This declares the function `cgi_error` with the attribute `__noreturn__` to
hint to GCC/Clang that the function exits the program and to prevent
implicit-fallthrough warnings in the function `handle_fcgi_request`.