### PR TITLE
build: fix compile error on gcc7

### DIFF
--- a/fcgiwrap.c
+++ b/fcgiwrap.c
@@ -579,6 +579,7 @@ static void handle_fcgi_request(void)
 
 			execl(filename, filename, (void *)NULL);
 			cgi_error("502 Bad Gateway", "Cannot execute script", filename);
+			break;
 
 		default: /* parent */
 			close(pipe_in[0]);


### PR DESCRIPTION
gcc7 complains about an implicit fallthrough here. Is this intentional?