### PR TITLE
Add environment variable NO_BUFFERING to disable output buffering

### DIFF
--- a/fcgiwrap.8
+++ b/fcgiwrap.8
@@ -71,6 +71,10 @@ FCGI_CHDIR
 By default fcgiwrap changes to the directory containing the CGI script before executing it (per CGI spec).
 You may override this behaviour by passing FCGI_CHDIR containing the script's expected working directory
 or \- to skip the directory change completely.
+.RE
+NO_BUFFERING
+.RS
+When set (e.g., to ""), disables output buffering.
 
 .SH EXAMPLE
 The fastest way to see \fBfcgiwrap\fP do something is to launch it at the command line


### PR DESCRIPTION
Fixes #36