### PR TITLE
Zero-out the sockaddr struct before using it

### DIFF
--- a/fcgiwrap.c
+++ b/fcgiwrap.c
@@ -726,6 +726,8 @@ static int setup_socket(char *url) {
 		struct sockaddr_in6 sa_in6;
 	} sa;
 
+    memset(&sa, 0, sizeof(sa));
+
 	if (!strncmp(p, "unix:", sizeof("unix:") - 1)) {
 		p += sizeof("unix:") - 1;
 


### PR DESCRIPTION
It was reported that fcgiwrap doesn't work with IPv6, I start testing and found that the following command fails :

```
# /usr/local/sbin/fcgiwrap -s 'tcp6:[::1]:899'
Failed to bind: Can't assign requested address
```
After investigations I found that the issue was caused by an uninitialized  sockaddr structure which is mandatory for IPv6. After that, fcgiwrap binds on IPv6 addresses without issue.