### PR TITLE
Cleanup children in prefork mode, annotate `NORETURN` to fix implicit fallthrough

### DIFF
--- a/fcgiwrap.c
+++ b/fcgiwrap.c
@@ -793,18 +793,30 @@ invalid_url:
 	fd = socket(sa.sa.sa_family, SOCK_STREAM, 0);
 	if (fd < 0) {
 		perror("Failed to create socket");
-		return -1;
+		goto cleanup_socket;
 	}
 	if (bind(fd, &sa.sa, sockaddr_size) < 0) {
 		perror("Failed to bind");
-		return -1;
+		goto cleanup_fd;
 	}
 
 	if (listen_on_fd(fd) < 0) {
-		return -1;
+		goto cleanup_fd;
 	}
 
 	return fd;
+
+cleanup_fd:
+
+	close(fd);
+
+cleanup_socket:
+
+	if(sa.sa.sa_family == AF_UNIX) {
+		unlink(sa.sa_un.sun_path);
+	}
+
+	return -1;
 }
 
 int main(int argc, char **argv)

--- a/fcgiwrap.c
+++ b/fcgiwrap.c
@@ -56,6 +56,12 @@
 #define UNIX_PATH_MAX 108
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+# define NORETURN __attribute__((__noreturn__))
+#else
+# define NORETURN
+#endif
+
 extern char **environ;
 static char * const * inherited_environ;
 static const char **allowed_programs;
@@ -500,7 +506,7 @@ static bool is_allowed_program(const char *program) {
 	return false;
 }
 
-static void cgi_error(const char *message, const char *reason, const char *filename)
+static void NORETURN cgi_error(const char *message, const char *reason, const char *filename)
 {
 	printf("Status: %s\r\nContent-Type: text/plain\r\n\r\n%s\r\n",
 		message, message);


### PR DESCRIPTION
This PR primarily addresses issue #19, although it tackles other issues as well. When the `prefork` option is specified via the command line, the initial process spawns a set number of child processes within a control loop. While there is a provision to reap these child processes upon their exit, the master process currently lacks a mechanism to notify them to terminate when it receives a `SIGTERM` or `SIGINT`. This behavior can be problematic due to variations in how different init systems and third-party managers handle program management. For example, `systemd` in its default configuration sends `SIGTERM` signals to all processes in the control group. However, this is not universally true; Docker, for instance, sends a `SIGTERM` only to the process specified in the `ENTRYPOINT` instruction.

Key Fixes and Improvements:

- Resolves issue #57: Although other PRs like #54 and #43 have attempted to fix this issue, this PR employs the `NORETURN` annotation as a cleaner solution. This change was necessary for successful compilation.
- Resolves issue #19: The master process now issues `SIGTERM` signals to all processes in the process group upon its exit, thereby ensuring graceful termination.
- Refines error handling: This PR streamlines error handling by eliminating duplicate calls and also removes the domain socket in the event of an error.

I'm up and running with these patches but have not tested this extensively. If maintainers consider merging this, I will follow up. I welcome community feedback.