### PR TITLE
Allow no response headers

### DIFF
--- a/fcgiwrap.c
+++ b/fcgiwrap.c
@@ -500,6 +500,7 @@ static bool is_allowed_program(const char *program) {
 	return false;
 }
 
+__attribute__((__noreturn__))
 static void cgi_error(const char *message, const char *reason, const char *filename)
 {
 	printf("Status: %s\r\nContent-Type: text/plain\r\n\r\n%s\r\n",

--- a/fcgiwrap.c
+++ b/fcgiwrap.c
@@ -150,8 +150,8 @@ enum char_class_t {
 static const unsigned char header_state_machine[REPLY_STATE_MAX][CC_MAX] = {
 	[REPLY_STATE_INIT] = {
 		[CC_NORMAL] = REPLY_STATE_HEADER,
-		[CC_CR] = ACTION_ERROR,
-		[CC_LF] = ACTION_ERROR,
+		[CC_CR] = REPLY_STATE_BODY | ACTION_END,
+		[CC_LF] = REPLY_STATE_BODY | ACTION_END,
 	},
 	[REPLY_STATE_HEADER] = {
 		[CC_NORMAL] = REPLY_STATE_HEADER,


### PR DESCRIPTION
Currently it isn't possible for a script to not set any response headers.

Fcgiwrap already some work to allow the omission of carriage returns, I slightly altered the statemachine responsible for this to allow for responses with no response headers.

Although response headers are technically required according to rfc3875 it is sometimes omitted.

For instance `mod_cgi` of lighthttpd will work with just the body:
https://github.com/lighttpd/lighttpd1.4/blob/master/src/mod_cgi.c#L631-L639

With this PR a response can now start with a linefeed and then begin it's body.

Additionally I marked cgi_error `__noreturn__`  as a fix for https://github.com/gnosek/fcgiwrap/issues/57.

fixes https://github.com/gnosek/fcgiwrap/issues/57
